### PR TITLE
Use provided three.js canvas ID in three.js helper

### DIFF
--- a/helpers/JeelizThreejsHelper.js
+++ b/helpers/JeelizThreejsHelper.js
@@ -182,7 +182,7 @@ THREE.JeelizHelper=(function(){
             if (spec.threejsCanvasId){
                 _isSeparateThreejsCanvas=true;
                 //set the threejs canvas size to the threejs canvas
-                threejsCanvas=document.getElementById('threejsCanvas');
+                threejsCanvas=document.getElementById(spec.threejsCanvasId);
                 threejsCanvas.setAttribute('width', _faceFilterCv.width);
                 threejsCanvas.setAttribute('height', _faceFilterCv.height);
             } else {


### PR DESCRIPTION
Currently, the API of the three.js helper allows a canvas ID to be passed in for the three.js canvas, but that parameter is ignored when finding the canvas in the DOM. This change fixes that behavior to respect the canvas ID that is passed in.