### PR TITLE
add the devicePixelRatio to the window.width and window.height to mak…

### DIFF
--- a/helpers/JeelizResizer.js
+++ b/helpers/JeelizResizer.js
@@ -175,7 +175,12 @@ const JeelizResizer = (function(){
 
       //sort camera resolutions from the best to the worst :
       allResolutions.sort(function(resA, resB){
-        return compute_overlap(resB, _whCanvasPx)-compute_overlap(resA, _whCanvasPx);
+        // To find the correct resolution for iOS one should consider the window.devicePixelRatio factor
+        let dpr = 1
+        if (/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream) {
+          dpr = window.devicePixelRatio;
+        }
+        return compute_overlap(resB, [_whCanvasPx[0] * dpr, _whCanvasPx[1] * dpr])-compute_overlap(resA, [_whCanvasPx[0] * dpr, _whCanvasPx[1] * dpr]);        
       });
 
       //pick the best camera resolution


### PR DESCRIPTION
I found that on iOS the camera resolution when using the provided resolution from JeelizResizer is always very low. I looked into that and found that it can be improved with the changes I made. 

Have a look and let me know if that is useful for you