### PR TITLE
[FIX] deep clone camera resolutions

### DIFF
--- a/helpers/JeelizResizer.js
+++ b/helpers/JeelizResizer.js
@@ -244,7 +244,9 @@ var JeelizResizer = (function(){
       }
 
       // compute the best camera resolutions:
-      const allResolutions = _cameraResolutions.slice(0);
+      const allResolutions = _cameraResolutions.map(function(x){
+        return x.slice(0)
+      });
 
       // if we are in portrait mode, the camera is also in portrait mode
       // so we need to set all resolutions to portrait mode


### PR DESCRIPTION
Fix deep clone of camera resolutions array : internal arrays where cloned as references, not as new arrays; now 'size_canvas' returns correct resolution no matter how many times it is triggered (with same input params)